### PR TITLE
Change ping function to return string

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -28,9 +28,10 @@ export default class Rpc extends RpcBase {
         }
     }
 
-    async ping(_params?: {}, id?: string | number | null): Promise<void> {
+    async ping(_params?: {}, id?: string | number | null): Promise<string> {
         const method = "ping";
-        await this.call({ method, id });
+        const response = await this.call({ method, id });
+        return response.result;
     }
 
     async version(_params?: {}, id?: string | number | null): Promise<string> {


### PR DESCRIPTION
Foundry is returning pong in the ping request. The current foundry-rpc-js is returning nothing in the ping RPC. I want to make the ping in the foundry-rpc-js to return pong.