### PR TITLE
Change build based on new getPendingTransaction function 

### DIFF
--- a/build/src/chain.d.ts
+++ b/build/src/chain.d.ts
@@ -10,7 +10,7 @@ export declare type Block = {
     score: string | number;
     seal: number[][];
     stateRoot: string;
-    nextValidatorSetHash: string;
+    validatorSetRoot: string;
     timestamp: number;
     transactions: Transaction[];
     transactionsRoot: string;

--- a/build/src/mempool.d.ts
+++ b/build/src/mempool.d.ts
@@ -15,6 +15,7 @@ export default class Mempool extends RpcBase {
     getPendingTransactions(params?: {
         from?: number | null;
         to?: number | null;
+        futureIncluded?: boolean;
     }, id?: string | number | null): Promise<{
         transactions: Object[];
         lastTimestamp: number;

--- a/build/src/mempool.js
+++ b/build/src/mempool.js
@@ -121,14 +121,15 @@ var Mempool = /** @class */ (function (_super) {
     Mempool.prototype.getPendingTransactions = function (params, id) {
         if (params === void 0) { params = {}; }
         return __awaiter(this, void 0, void 0, function () {
-            var method, from, to, response;
+            var method, from, to, futureIncluded, response;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         method = "mempool_getPendingTransactions";
                         from = params.from == null ? null : params.from;
                         to = params.to == null ? null : params.to;
-                        return [4 /*yield*/, this.call({ method: method, id: id }, from, to)];
+                        futureIncluded = params.futureIncluded == null ? false : params.futureIncluded;
+                        return [4 /*yield*/, this.call({ method: method, id: id }, from, to, futureIncluded)];
                     case 1:
                         response = _a.sent();
                         return [2 /*return*/, response.result];


### PR DESCRIPTION
New getPendingTransaction is supposed to include future transactions as well. Therefore, a new build is needed for foundry tests. 